### PR TITLE
Client preset initial setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@types/node": "^16.18.23",
         "@types/react": "^18.0.33",
         "@types/react-dom": "^18.0.11",
-        "graphql.macro": "^1.4.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -6323,19 +6322,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/babel-literal-to-ast": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/babel-literal-to-ast/-/babel-literal-to-ast-2.1.0.tgz",
-      "integrity": "sha512-CxfpQ0ysQ0bZOhlaPgcWjl79Em16Rhqc6++UAFn0A3duiXmuyhhj8yyl9PYbj0I0CyjrHovdDbp2QEKT7uIMxw==",
-      "dependencies": {
-        "@babel/parser": "^7.1.6",
-        "@babel/traverse": "^7.1.6",
-        "@babel/types": "^7.1.6"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.1.2"
-      }
-    },
     "node_modules/babel-loader": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.3.0.tgz",
@@ -10303,42 +10289,6 @@
       },
       "peerDependencies": {
         "graphql": ">=0.11 <=16"
-      }
-    },
-    "node_modules/graphql.macro": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/graphql.macro/-/graphql.macro-1.4.2.tgz",
-      "integrity": "sha512-vcIaStPgS65gp5i1M3DSBimNVkyus0Z7k4VObWAyZS319tKlpX/TEIJSWTgOZU5k8dn4RRzGoS/elQhX2E6yBw==",
-      "dependencies": {
-        "@babel/template": "^7.4.4",
-        "babel-literal-to-ast": "^2.1.0",
-        "babel-plugin-macros": "^2.5.0",
-        "graphql-tag": "^2.10.1"
-      }
-    },
-    "node_modules/graphql.macro/node_modules/babel-plugin-macros": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "cosmiconfig": "^6.0.0",
-        "resolve": "^1.12.0"
-      }
-    },
-    "node_modules/graphql.macro/node_modules/cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/gzip-size": {
@@ -24628,16 +24578,6 @@
         }
       }
     },
-    "babel-literal-to-ast": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/babel-literal-to-ast/-/babel-literal-to-ast-2.1.0.tgz",
-      "integrity": "sha512-CxfpQ0ysQ0bZOhlaPgcWjl79Em16Rhqc6++UAFn0A3duiXmuyhhj8yyl9PYbj0I0CyjrHovdDbp2QEKT7uIMxw==",
-      "requires": {
-        "@babel/parser": "^7.1.6",
-        "@babel/traverse": "^7.1.6",
-        "@babel/types": "^7.1.6"
-      }
-    },
     "babel-loader": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.3.0.tgz",
@@ -27556,41 +27496,6 @@
       "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.12.0.tgz",
       "integrity": "sha512-PA3ImUp8utrpEjoxBMhvxsjkStvFEdU0E1gEBREt8HZIWkxOUymwJBhFnBL7t/iHhUq1GVPeZevPinkZFENxTw==",
       "requires": {}
-    },
-    "graphql.macro": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/graphql.macro/-/graphql.macro-1.4.2.tgz",
-      "integrity": "sha512-vcIaStPgS65gp5i1M3DSBimNVkyus0Z7k4VObWAyZS319tKlpX/TEIJSWTgOZU5k8dn4RRzGoS/elQhX2E6yBw==",
-      "requires": {
-        "@babel/template": "^7.4.4",
-        "babel-literal-to-ast": "^2.1.0",
-        "babel-plugin-macros": "^2.5.0",
-        "graphql-tag": "^2.10.1"
-      },
-      "dependencies": {
-        "babel-plugin-macros": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-          "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
-          "requires": {
-            "@babel/runtime": "^7.7.2",
-            "cosmiconfig": "^6.0.0",
-            "resolve": "^1.12.0"
-          }
-        },
-        "cosmiconfig": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-          "requires": {
-            "@types/parse-json": "^4.0.0",
-            "import-fresh": "^3.1.0",
-            "parse-json": "^5.0.0",
-            "path-type": "^4.0.0",
-            "yaml": "^1.7.2"
-          }
-        }
-      }
     },
     "gzip-size": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2687,14 +2687,6 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-typed-document-node/core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
-      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-codegen/core": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-3.1.0.tgz",
@@ -3080,6 +3072,14 @@
         }
       }
     },
+    "node_modules/@graphql-tools/executor/node_modules/@graphql-typed-document-node/core": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.2.tgz",
+      "integrity": "sha512-9anpBMM9mEgZN4wr2v8wHJI2/u5TnnggewRN6OlvXTTnuVyoY19X6rOv9XTqKRw6dcGKwZsBi8n0kDE2I5i4VA==",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@graphql-tools/git-loader": {
       "version": "7.2.20",
       "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-7.2.20.tgz",
@@ -3441,9 +3441,9 @@
       }
     },
     "node_modules/@graphql-typed-document-node/core": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.2.tgz",
-      "integrity": "sha512-9anpBMM9mEgZN4wr2v8wHJI2/u5TnnggewRN6OlvXTTnuVyoY19X6rOv9XTqKRw6dcGKwZsBi8n0kDE2I5i4VA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
@@ -21861,14 +21861,6 @@
         "@graphql-tools/utils": "^9.0.0",
         "@graphql-typed-document-node/core": "3.2.0",
         "tslib": "~2.5.0"
-      },
-      "dependencies": {
-        "@graphql-typed-document-node/core": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
-          "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
-          "requires": {}
-        }
       }
     },
     "@graphql-codegen/core": {
@@ -22111,6 +22103,14 @@
         "@repeaterjs/repeater": "3.0.4",
         "tslib": "^2.4.0",
         "value-or-promise": "1.0.12"
+      },
+      "dependencies": {
+        "@graphql-typed-document-node/core": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.2.tgz",
+          "integrity": "sha512-9anpBMM9mEgZN4wr2v8wHJI2/u5TnnggewRN6OlvXTTnuVyoY19X6rOv9XTqKRw6dcGKwZsBi8n0kDE2I5i4VA==",
+          "requires": {}
+        }
       }
     },
     "@graphql-tools/executor-graphql-ws": {
@@ -22443,9 +22443,9 @@
       }
     },
     "@graphql-typed-document-node/core": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.2.tgz",
-      "integrity": "sha512-9anpBMM9mEgZN4wr2v8wHJI2/u5TnnggewRN6OlvXTTnuVyoY19X6rOv9XTqKRw6dcGKwZsBi8n0kDE2I5i4VA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
       "requires": {}
     },
     "@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@types/node": "^16.18.23",
     "@types/react": "^18.0.33",
     "@types/react-dom": "^18.0.11",
-    "graphql.macro": "^1.4.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/src/common/graphql/types/gql.ts
+++ b/src/common/graphql/types/gql.ts
@@ -14,7 +14,7 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  */
 const documents = {
     "\n  fragment Count on Characters {\n    info {\n      count\n    }\n  }\n": types.CountFragmentDoc,
-    "\n  \n  query GetCharacters {\n    characters {\n      ...Count\n    }\n  }\n": types.GetCharactersDocument,
+    "\n  query GetCharacters {\n    characters {\n      ...Count\n    }\n  }\n": types.GetCharactersDocument,
 };
 
 /**
@@ -38,7 +38,7 @@ export function graphql(source: "\n  fragment Count on Characters {\n    info {\
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  \n  query GetCharacters {\n    characters {\n      ...Count\n    }\n  }\n"): (typeof documents)["\n  \n  query GetCharacters {\n    characters {\n      ...Count\n    }\n  }\n"];
+export function graphql(source: "\n  query GetCharacters {\n    characters {\n      ...Count\n    }\n  }\n"): (typeof documents)["\n  query GetCharacters {\n    characters {\n      ...Count\n    }\n  }\n"];
 
 export function graphql(source: string) {
   return (documents as any)[source] ?? {};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,13 @@
 import * as React from "react";
 import { render } from "react-dom";
 
-import { ApolloClient, ApolloProvider, useQuery, InMemoryCache } from "@apollo/client";
+import {
+  ApolloClient,
+  ApolloProvider,
+  useQuery,
+  InMemoryCache,
+} from "@apollo/client";
 import { GET_CHARACTER } from "./queries";
-import { GetCharactersQuery } from "./common/graphql/types/graphql";
 
 const client = new ApolloClient({
   uri: "https://rickandmortyapi.com/graphql",
@@ -11,7 +15,7 @@ const client = new ApolloClient({
 });
 
 const ShowPosts = () => {
-  const { loading, error, data } = useQuery<GetCharactersQuery>(GET_CHARACTER);
+  const { loading, error, data } = useQuery(GET_CHARACTER);
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error :(</p>;
@@ -27,4 +31,3 @@ const App = () => (
 
 const rootElement = document.getElementById("root");
 render(<App />, rootElement);
-

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1,18 +1,17 @@
-import { gql } from "graphql.macro";
+import { graphql } from "./common/graphql/types";
 
-const COUNT_FRAGMENT = gql`
+graphql(`
   fragment Count on Characters {
     info {
       count
     }
   }
-`;
+`);
 
-export const GET_CHARACTER = gql`
-  ${COUNT_FRAGMENT}
+export const GET_CHARACTER = graphql(`
   query GetCharacters {
     characters {
       ...Count
     }
   }
-`;
+`);


### PR DESCRIPTION
In answer to https://github.com/dotansimha/graphql-code-generator/discussions/9271.

> **Note**: All commits are relevant here.

With GraphQL codegen & `client-preset`, we can leverage generated `graphql` functions so we don't have to type `useQuery` manually, and we can rely automatically on generated types. To do so, we need to use the generated `graphql` function rather than `graphql.macro`.

I noticed it had the wrong version of `@graphql-typed-document-node/core` which will break fragment masking. I updated it.